### PR TITLE
feat: 강의 생성 기능을 구현

### DIFF
--- a/src/main/java/com/example/demo/api/controller/CourseController.java
+++ b/src/main/java/com/example/demo/api/controller/CourseController.java
@@ -1,0 +1,25 @@
+package com.example.demo.api.controller;
+
+import com.example.demo.api.dto.CourseCreateDto;
+import com.example.demo.api.service.CourseService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users")
+public class CourseController {
+    private final CourseService courseService;
+
+    @PostMapping("/{userId}/courses")
+    public ResponseEntity<String> createCourse(
+            @PathVariable Long userId,
+            @RequestBody @Valid CourseCreateDto dto
+    ) {
+        courseService.create(userId, dto);
+        return ResponseEntity.status(HttpStatus.CREATED).body("강의가 생성되었습니다.");
+    }
+}

--- a/src/main/java/com/example/demo/api/controller/UserController.java
+++ b/src/main/java/com/example/demo/api/controller/UserController.java
@@ -20,6 +20,6 @@ public class UserController {
     @PostMapping
     public ResponseEntity<String> create(@Valid @RequestBody UserCreateDto dto) {
         userService.signUp(dto);
-        return ResponseEntity.status(HttpStatus.CREATED).body("예약이 성공적으로 생성되었습니다.");
+        return ResponseEntity.status(HttpStatus.CREATED).body("회원가입 성공하셨습니다.");
     }
 }

--- a/src/main/java/com/example/demo/api/dto/CourseCreateDto.java
+++ b/src/main/java/com/example/demo/api/dto/CourseCreateDto.java
@@ -1,0 +1,33 @@
+package com.example.demo.api.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
+
+public record CourseCreateDto(
+        @NotBlank(message = "강의 제목은 필수입니다.")
+        @Size(max = 100, message = "강의 제목은 100자 이하여야 합니다.")
+        String title,
+
+        @NotBlank(message = "강의 설명은 필수입니다.")
+        @Size(max = 1000, message = "강의 설명은 1000자 이하여야 합니다.")
+        String description,
+
+        @NotNull(message = "가격은 필수입니다.")
+        @Min(value = 0, message = "가격은 0원 이상이어야 합니다.")
+        Integer price,
+
+        @NotNull(message = "정원은 필수입니다.")
+        @Min(value = 1, message = "정원은 최소 1명 이상이어야 합니다.")
+        Integer maxCapacity,
+
+        @NotNull(message = "시작일은 필수입니다.")
+        LocalDate startedAt,
+
+        @NotNull(message = "종료일은 필수입니다.")
+        LocalDate endedAt
+) {
+}

--- a/src/main/java/com/example/demo/api/persistence/entity/Course.java
+++ b/src/main/java/com/example/demo/api/persistence/entity/Course.java
@@ -1,0 +1,94 @@
+package com.example.demo.api.persistence.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Table(name = "tbl_course")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Course {
+    @Id
+    @Column(name = "id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "title", nullable = false, length = 100)
+    private String title;
+
+    @Column(name = "description", nullable = false, length = 1000)
+    private String description;
+
+    @Column(name = "price", nullable = false)
+    private int price;
+
+    @Column(name = "max_capacity", nullable = false)
+    private int maxCapacity;
+
+    @Column(name = "current_capacity", nullable = false)
+    private int currentCapacity;
+
+    @Column(name = "started_at", updatable = false, nullable = false)
+    private LocalDate startedAt;
+
+    @Column(name = "ended_at", updatable = false, nullable = false)
+    private LocalDate endedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private CourseStatus courseStatus;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Builder
+    private Course(
+            String title,
+            String description,
+            int price,
+            int maxCapacity,
+            int currentCapacity,
+            LocalDate startedAt,
+            LocalDate endedAt,
+            CourseStatus status,
+            User user
+    ) {
+        this.title = title;
+        this.description = description;
+        this.price = price;
+        this.maxCapacity = maxCapacity;
+        this.currentCapacity = currentCapacity;
+        this.startedAt = startedAt;
+        this.endedAt = endedAt;
+        this.courseStatus = status;
+        this.user = user;
+    }
+
+    public static Course create(
+            String title,
+            String description,
+            int price,
+            int maxCapacity,
+            LocalDate startedAt,
+            LocalDate endedAt,
+            User user
+    ) {
+        return Course.builder()
+                .title(title)
+                .description(description)
+                .price(price)
+                .maxCapacity(maxCapacity)
+                .currentCapacity(0)
+                .startedAt(startedAt)
+                .endedAt(endedAt)
+                .status(CourseStatus.DRAFT)
+                .user(user)
+                .build();
+    }
+}

--- a/src/main/java/com/example/demo/api/persistence/entity/CourseStatus.java
+++ b/src/main/java/com/example/demo/api/persistence/entity/CourseStatus.java
@@ -1,0 +1,7 @@
+package com.example.demo.api.persistence.entity;
+
+public enum CourseStatus {
+    DRAFT,
+    OPEN,
+    CLOSED
+}

--- a/src/main/java/com/example/demo/api/persistence/entity/User.java
+++ b/src/main/java/com/example/demo/api/persistence/entity/User.java
@@ -11,7 +11,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Getter
 @Table(name = "tbl_user")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EntityListeners(AuditingEntityListener.class)
 public class User {
     @Id
     @Column(name = "id")

--- a/src/main/java/com/example/demo/api/persistence/repository/CourseRepository.java
+++ b/src/main/java/com/example/demo/api/persistence/repository/CourseRepository.java
@@ -1,0 +1,7 @@
+package com.example.demo.api.persistence.repository;
+
+import com.example.demo.api.persistence.entity.Course;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CourseRepository extends JpaRepository<Course, Long> {
+}

--- a/src/main/java/com/example/demo/api/service/CourseService.java
+++ b/src/main/java/com/example/demo/api/service/CourseService.java
@@ -1,0 +1,55 @@
+package com.example.demo.api.service;
+
+import com.example.demo.api.dto.CourseCreateDto;
+import com.example.demo.api.persistence.entity.Course;
+import com.example.demo.api.persistence.entity.Role;
+import com.example.demo.api.persistence.entity.User;
+import com.example.demo.api.persistence.repository.CourseRepository;
+import com.example.demo.api.persistence.repository.UserRepository;
+import com.example.demo.error.exception.BadRequestException;
+import com.example.demo.error.exception.NotFoundException;
+import com.example.demo.error.model.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CourseService {
+
+    private final CourseRepository courseRepository;
+    private final UserRepository userRepository;
+
+    public void create(Long userId, CourseCreateDto dto) {
+        final User user = userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_NOT_USER));
+
+        validateCreator(user);
+        validateDate(dto);
+
+        final Course course = Course.create(
+                dto.title(),
+                dto.description(),
+                dto.price(),
+                dto.maxCapacity(),
+                dto.startedAt(),
+                dto.endedAt(),
+                user
+        );
+
+        courseRepository.save(course);
+    }
+
+    private void validateCreator(User user) {
+        if (user.getRole() != Role.CREATOR) {
+            throw new BadRequestException(ErrorCode.INVALID_ROLE);
+        }
+    }
+
+    private void validateDate(CourseCreateDto dto) {
+        if (dto.startedAt().isAfter(dto.endedAt())) {
+            throw new BadRequestException(ErrorCode.INVALID_DATE_RANGE);
+        }
+    }
+}

--- a/src/main/java/com/example/demo/error/model/ErrorCode.java
+++ b/src/main/java/com/example/demo/error/model/ErrorCode.java
@@ -9,8 +9,12 @@ import org.springframework.http.HttpStatus;
 @NoArgsConstructor
 @AllArgsConstructor
 public enum ErrorCode {
-    //BadRequest 400 error
-    DUPLICATE_USER_NAME("중복된 이름이 존재합니다.", HttpStatus.BAD_REQUEST);
+    //NotFound 404 error
+    FAIL_NOT_USER("해당 유저를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+
+    // BadRequest 400
+    INVALID_ROLE("강의 생성은 강사만 가능합니다.", HttpStatus.BAD_REQUEST),
+    INVALID_DATE_RANGE("시작일은 종료일보다 이후일 수 없습니다.", HttpStatus.BAD_REQUEST);
 
     private String message;
     private HttpStatus statusCode;


### PR DESCRIPTION
## 📋 CheckList
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. feat: 유저 조회 기능 구현)
- [x] 🏷️ 라벨, 프로젝트는 등록했나요?
- [x] 🧹 코드 스멜은 해결했나요?

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

* close #3 

## 👩‍💻 공유 포인트 및 논의 사항
* 공유 포인트 및 논의 사항 
* 강의 생성은 CREATOR 권한을 가진 사용자만 가능하도록 검증했습니다.
* 강의 생성 시 초기 상태는 요구사항에 맞게 DRAFT로 설정했습니다.
* currentCapacity 필드를 별도로 두었습니다. 강의 목록/상세 조회 시 현재 신청 인원을 자주 보여줄 가능성이 높다고 판단했고, 매번 Enrollment를 count하는 방식은 조회가 많아질수록 DB 부하가 커질 수 있다고 판단해 조회 성능을 고려해 현재 수강 인원을 필드로 관리하도록 설계했습니다.