### PR TITLE
feat: 수강 오픈을 구현

### DIFF
--- a/src/main/java/com/example/demo/api/controller/CourseController.java
+++ b/src/main/java/com/example/demo/api/controller/CourseController.java
@@ -22,4 +22,13 @@ public class CourseController {
         courseService.create(userId, dto);
         return ResponseEntity.status(HttpStatus.CREATED).body("강의가 생성되었습니다.");
     }
+
+    @PostMapping("/{userId}/courses/{courseId}/open")
+    public ResponseEntity<String> openCourse(
+            @PathVariable Long userId,
+            @PathVariable Long courseId
+    ) {
+        courseService.openCourse(userId, courseId);
+        return ResponseEntity.ok("강의가 오픈되었습니다.");
+    }
 }

--- a/src/main/java/com/example/demo/api/persistence/entity/Course.java
+++ b/src/main/java/com/example/demo/api/persistence/entity/Course.java
@@ -91,4 +91,8 @@ public class Course {
                 .user(user)
                 .build();
     }
+
+    public void open() {
+        this.courseStatus = CourseStatus.OPEN;
+    }
 }

--- a/src/main/java/com/example/demo/api/service/CourseService.java
+++ b/src/main/java/com/example/demo/api/service/CourseService.java
@@ -2,6 +2,7 @@ package com.example.demo.api.service;
 
 import com.example.demo.api.dto.CourseCreateDto;
 import com.example.demo.api.persistence.entity.Course;
+import com.example.demo.api.persistence.entity.CourseStatus;
 import com.example.demo.api.persistence.entity.Role;
 import com.example.demo.api.persistence.entity.User;
 import com.example.demo.api.persistence.repository.CourseRepository;
@@ -12,6 +13,8 @@ import com.example.demo.error.model.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
 
 @Service
 @Transactional
@@ -41,6 +44,20 @@ public class CourseService {
         courseRepository.save(course);
     }
 
+    public void openCourse(Long userId, Long courseId) {
+        final User user = userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_NOT_USER));
+
+        final Course course = courseRepository.findById(courseId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_NOT_COURSE));
+
+        validateCourseOwner(user, course);
+        validateOpenStatus(course);
+        validateCourseNotEnded(course);
+
+        course.open();
+    }
+
     private void validateCreator(User user) {
         if (user.getRole() != Role.CREATOR) {
             throw new BadRequestException(ErrorCode.INVALID_ROLE);
@@ -50,6 +67,25 @@ public class CourseService {
     private void validateDate(CourseCreateDto dto) {
         if (dto.startedAt().isAfter(dto.endedAt())) {
             throw new BadRequestException(ErrorCode.INVALID_DATE_RANGE);
+        }
+    }
+
+
+    private void validateCourseOwner(User user, Course course) {
+        if (!course.getUser().getId().equals(user.getId())) {
+            throw new BadRequestException(ErrorCode.INVALID_COURSE_OWNER);
+        }
+    }
+
+    private void validateOpenStatus(Course course) {
+        if (course.getCourseStatus() != CourseStatus.DRAFT) {
+            throw new BadRequestException(ErrorCode.INVALID_COURSE_STATUS);
+        }
+    }
+
+    private void validateCourseNotEnded(Course course) {
+        if (course.getEndedAt().isBefore(LocalDate.now())) {
+            throw new BadRequestException(ErrorCode.INVALID_COURSE_PERIOD);
         }
     }
 }

--- a/src/main/java/com/example/demo/error/model/ErrorCode.java
+++ b/src/main/java/com/example/demo/error/model/ErrorCode.java
@@ -11,10 +11,14 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     //NotFound 404 error
     FAIL_NOT_USER("해당 유저를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-
+    FAIL_NOT_COURSE("해당 강의를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     // BadRequest 400
     INVALID_ROLE("강의 생성은 강사만 가능합니다.", HttpStatus.BAD_REQUEST),
-    INVALID_DATE_RANGE("시작일은 종료일보다 이후일 수 없습니다.", HttpStatus.BAD_REQUEST);
+    INVALID_DATE_RANGE("시작일은 종료일보다 이후일 수 없습니다.", HttpStatus.BAD_REQUEST),
+
+    INVALID_COURSE_OWNER("본인이 생성한 강의만 오픈할 수 있습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_COURSE_PERIOD("이미 종료된 강의는 오픈할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_COURSE_STATUS("현재 강의 상태에서는 오픈할 수 없습니다.", HttpStatus.BAD_REQUEST);
 
     private String message;
     private HttpStatus statusCode;


### PR DESCRIPTION
## 📋 CheckList
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. feat: 유저 조회 기능 구현)
- [x] 🏷️ 라벨, 프로젝트는 등록했나요?
- [x] 🧹 코드 스멜은 해결했나요?

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

* close #5 

## 👩‍💻 공유 포인트 및 논의 사항
* 공유 포인트 및 논의 사항 
* 강의 오픈 시 다음과 같은 검증 로직을 분리하여 적용했습니다.
* 요청한 사용자가 해당 강의의 생성자인지 검증
* 현재 강의 상태가 DRAFT인지 검증 (이미 OPEN/CLOSED 상태인 경우 방지)
* 강의 종료일이 현재 날짜 이전인지 검증 (이미 종료된 강의 오픈 방지)

* 강의 오픈은 스케줄러를 통한 자동 처리 대신, 강사의 명시적인 요청을 통해 상태를 변경하는 방식으로 구현했습니다.
* 이를 통해 강의 생성과 모집 시작 시점을 분리하고 도메인 흐름(DRAFT → OPEN → CLOSED)을 명확하게 표현하고자 했습니다.