### PR TITLE
feat: 수강 취소를 구현

### DIFF
--- a/src/main/java/com/example/demo/api/controller/EnrollmentController.java
+++ b/src/main/java/com/example/demo/api/controller/EnrollmentController.java
@@ -28,4 +28,13 @@ public class EnrollmentController {
         enrollmentService.confirm(userId, enrollmentId);
         return ResponseEntity.ok("결제가 완료되었습니다.");
     }
+
+    @PostMapping("/{enrollmentId}/cancel")
+    public ResponseEntity<String> cancel(
+            @RequestParam Long userId,
+            @PathVariable Long enrollmentId
+    ) {
+        enrollmentService.cancel(userId, enrollmentId);
+        return ResponseEntity.ok("수강 신청이 취소되었습니다.");
+    }
 }

--- a/src/main/java/com/example/demo/api/persistence/entity/Course.java
+++ b/src/main/java/com/example/demo/api/persistence/entity/Course.java
@@ -122,4 +122,8 @@ public class Course {
     public void open() {
         this.courseStatus = CourseStatus.OPEN;
     }
+
+    public void decreaseCapacity() {
+        this.currentCapacity--;
+    }
 }

--- a/src/main/java/com/example/demo/api/persistence/repository/EnrollmentRepository.java
+++ b/src/main/java/com/example/demo/api/persistence/repository/EnrollmentRepository.java
@@ -2,11 +2,28 @@ package com.example.demo.api.persistence.repository;
 
 import com.example.demo.api.persistence.entity.Course;
 import com.example.demo.api.persistence.entity.Enrollment;
+import com.example.demo.api.persistence.entity.EnrollmentStatus;
 import com.example.demo.api.persistence.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
     boolean existsByUserAndCourse(User user, Course course);
+
+    @Modifying(flushAutomatically = true)
+    @Query("""
+        update Enrollment e
+        set e.enrollmentStatus = :cancelledStatus
+        where e.id = :enrollmentId
+        and e.enrollmentStatus = :confirmedStatus
+        """)
+    int cancelIfConfirmed(
+            @Param("enrollmentId") Long enrollmentId,
+            @Param("confirmedStatus") EnrollmentStatus confirmedStatus,
+            @Param("cancelledStatus") EnrollmentStatus cancelledStatus
+    );
 }

--- a/src/main/java/com/example/demo/api/service/EnrollmentService.java
+++ b/src/main/java/com/example/demo/api/service/EnrollmentService.java
@@ -12,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -53,6 +55,48 @@ public class EnrollmentService {
         enrollment.confirm();
     }
 
+    public void cancel(Long userId, Long enrollmentId) {
+        final User user = userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_NOT_USER));
+
+        final Enrollment enrollment = enrollmentRepository.findById(enrollmentId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_NOT_ENROLLMENT));
+
+        validateEnrollmentOwner(user, enrollment);
+        validateConfirmed(enrollment);
+        validateCancelPeriod(enrollment);
+
+        final int cancelledCount = enrollmentRepository.cancelIfConfirmed(
+                enrollmentId,
+                EnrollmentStatus.CONFIRMED,
+                EnrollmentStatus.CANCELLED
+        );
+
+        validateCancelSuccess(cancelledCount);
+
+        enrollment.getCourse().decreaseCapacity();
+    }
+
+    private void validateConfirmed(Enrollment enrollment) {
+        if (enrollment.getEnrollmentStatus() != EnrollmentStatus.CONFIRMED) {
+            throw new BadRequestException(ErrorCode.INVALID_ENROLLMENT_CANCEL_STATUS);
+        }
+    }
+
+    private void validateCancelSuccess(int cancelledCount) {
+        if (cancelledCount == 0) {
+            throw new BadRequestException(ErrorCode.INVALID_ENROLLMENT_CANCEL_STATUS);
+        }
+    }
+
+    private void validateCancelPeriod(Enrollment enrollment) {
+        final LocalDateTime deadline = enrollment.getConfirmedAt().plusDays(7);
+
+        if (deadline.isBefore(LocalDateTime.now())) {
+            throw new BadRequestException(ErrorCode.INVALID_CANCEL_PERIOD);
+        }
+    }
+
     private void validateCapacityAvailable(int updatedCount) {
         if (updatedCount == 0) {
             throw new BadRequestException(ErrorCode.INVALID_COURSE_CAPACITY);
@@ -61,7 +105,7 @@ public class EnrollmentService {
 
     private void validateEnrollmentOwner(User user, Enrollment enrollment) {
         if (!enrollment.getUser().getId().equals(user.getId())) {
-            throw new BadRequestException(ErrorCode.INVALID_ENROLLMENT_CONFIRM_OWNER);
+            throw new BadRequestException(ErrorCode.INVALID_ENROLLMENT_OWNER);
         }
     }
 

--- a/src/main/java/com/example/demo/error/model/ErrorCode.java
+++ b/src/main/java/com/example/demo/error/model/ErrorCode.java
@@ -16,9 +16,11 @@ public enum ErrorCode {
 
     // BadRequest 400
     ALREADY_ENROLLED("이미 수강 신청한 강의입니다.", HttpStatus.BAD_REQUEST),
+    INVALID_ENROLLMENT_CANCEL_STATUS("결제 완료된 수강 신청만 취소할 수 있습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_CANCEL_PERIOD("결제 후 7일 이내에만 취소할 수 있습니다.", HttpStatus.BAD_REQUEST),
     INVALID_ENROLLMENT_CONFIRM_OWNER("본인의 수강 신청만 결제할 수 있습니다.", HttpStatus.BAD_REQUEST),
     INVALID_ENROLLMENT_CONFIRM_STATUS("결제 대기 상태의 수강 신청만 확정할 수 있습니다.", HttpStatus.BAD_REQUEST),
-    INVALID_ENROLLMENT_OWNER("본인이 생성한 강의에는 수강 신청할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_ENROLLMENT_OWNER("본인의 수강 신청만 접근할 수 있습니다.", HttpStatus.BAD_REQUEST),
     INVALID_ROLE("강의 생성은 강사만 가능합니다.", HttpStatus.BAD_REQUEST),
     INVALID_DATE_RANGE("시작일은 종료일보다 이후일 수 없습니다.", HttpStatus.BAD_REQUEST),
     INVALID_COURSE_OWNER("본인이 생성한 강의만 오픈할 수 있습니다.", HttpStatus.BAD_REQUEST),


### PR DESCRIPTION
## 📋 CheckList
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. feat: 유저 조회 기능 구현)
- [x] 🏷️ 라벨, 프로젝트는 등록했나요?
- [x] 🧹 코드 스멜은 해결했나요?

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

* close #15 

## 👩‍💻 공유 포인트 및 논의 사항
* 수강 취소는 CONFIRMED 상태의 수강 신청만 가능하도록 제한했습니다.
* 결제 완료 시점(confirmedAt)을 기준으로 7일 이내에만 취소 가능하도록 검증했습니다.
## 동시성 문제
* currentCapacity는 여러 요청이 동시에 접근할 수 있는 공유 자원이므로 동시성 문제를 고려했습니다.
* 사용자가 취소 버튼을 더블클릭하거나 동일 요청이 동시에 들어오는 경우, 현재 수강 인원이 중복 감소할 수 있습니다.
* 이를 방지하기 위해 Enrollment 상태를 CONFIRMED일 때만 CANCELLED로 변경하는 조건부 update를 사용했습니다.
* update 결과 row count가 1인 요청만 취소 성공으로 판단하고, 그 경우에만 currentCapacity를 감소시켰습니다.
* 이미 취소된 요청은 row count가 0이 되어 이후 감소 로직이 실행되지 않도록 처리했습니다.
