### PR TITLE
feat: 강의 별 수강생 목록을 구현

### DIFF
--- a/src/main/java/com/example/demo/api/controller/EnrollmentReadController.java
+++ b/src/main/java/com/example/demo/api/controller/EnrollmentReadController.java
@@ -1,5 +1,6 @@
 package com.example.demo.api.controller;
 
+import com.example.demo.api.dto.course.CourseStudentReadAllDto;
 import com.example.demo.api.dto.enrollment.EnrollmentReadAllDto;
 import com.example.demo.api.service.EnrollmentReadService;
 import lombok.RequiredArgsConstructor;
@@ -22,5 +23,15 @@ public class EnrollmentReadController {
             Pageable pageable
     ) {
         return ResponseEntity.ok(enrollmentReadService.readAllByUser(userId, pageable));
+    }
+
+    @GetMapping("/{userId}/courses/{courseId}/students")
+    public ResponseEntity<CourseStudentReadAllDto> readStudentsByCourse(
+            @PathVariable Long userId,
+            @PathVariable Long courseId
+    ) {
+        return ResponseEntity.ok(
+                enrollmentReadService.readStudentsByCourse(userId, courseId)
+        );
     }
 }

--- a/src/main/java/com/example/demo/api/dto/course/CourseStudentReadAllDto.java
+++ b/src/main/java/com/example/demo/api/dto/course/CourseStudentReadAllDto.java
@@ -1,0 +1,8 @@
+package com.example.demo.api.dto.course;
+
+import java.util.List;
+
+public record CourseStudentReadAllDto(
+        List<CourseStudentReadDto> students
+) {
+}

--- a/src/main/java/com/example/demo/api/dto/course/CourseStudentReadDto.java
+++ b/src/main/java/com/example/demo/api/dto/course/CourseStudentReadDto.java
@@ -1,0 +1,16 @@
+package com.example.demo.api.dto.course;
+
+import com.example.demo.api.persistence.entity.EnrollmentStatus;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record CourseStudentReadDto(
+        Long userId,
+        String userName,
+        Long enrollmentId,
+        EnrollmentStatus status,
+        LocalDateTime confirmedAt
+) {
+}

--- a/src/main/java/com/example/demo/api/persistence/entity/Enrollment.java
+++ b/src/main/java/com/example/demo/api/persistence/entity/Enrollment.java
@@ -1,5 +1,6 @@
 package com.example.demo.api.persistence.entity;
 
+import com.example.demo.api.dto.course.CourseStudentReadDto;
 import com.example.demo.api.dto.enrollment.EnrollmentReadDto;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -57,6 +58,16 @@ public class Enrollment {
                 .courseId(this.course.getId())
                 .courseTitle(this.course.getTitle())
                 .price(this.course.getPrice())
+                .status(this.enrollmentStatus)
+                .confirmedAt(this.confirmedAt)
+                .build();
+    }
+
+    public CourseStudentReadDto toStudentReadDto() {
+        return CourseStudentReadDto.builder()
+                .userId(this.user.getId())
+                .userName(this.user.getName())
+                .enrollmentId(this.id)
                 .status(this.enrollmentStatus)
                 .confirmedAt(this.confirmedAt)
                 .build();

--- a/src/main/java/com/example/demo/api/persistence/repository/EnrollmentRepository.java
+++ b/src/main/java/com/example/demo/api/persistence/repository/EnrollmentRepository.java
@@ -12,6 +12,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
     boolean existsByUserAndCourse(User user, Course course);
@@ -30,4 +32,6 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
     );
 
     Page<Enrollment> findAllByUser(User user, Pageable pageable);
+
+    List<Enrollment> findAllByCourseAndEnrollmentStatus(Course course, EnrollmentStatus enrollmentStatus);
 }

--- a/src/main/java/com/example/demo/api/service/EnrollmentCommandService.java
+++ b/src/main/java/com/example/demo/api/service/EnrollmentCommandService.java
@@ -30,7 +30,7 @@ public class EnrollmentCommandService {
 
         validateCourseOpen(course);
         validateCapacity(course);
-        validateAlreadyEnrolled(user, course);
+        validateAlreadyEnrolled(user, course); 
         validateNotCourseOwner(user, course);
 
         final Enrollment enrollment = Enrollment.create(user, course);
@@ -123,7 +123,7 @@ public class EnrollmentCommandService {
 
     private void validateNotCourseOwner(User user, Course course) {
         if (course.getUser().getId().equals(user.getId())) {
-            throw new BadRequestException(ErrorCode.INVALID_ENROLLMENT_OWNER);
+            throw new BadRequestException(ErrorCode.INVALID_SELF_ENROLLMENT);
         }
     }
 

--- a/src/main/java/com/example/demo/api/service/EnrollmentReadService.java
+++ b/src/main/java/com/example/demo/api/service/EnrollmentReadService.java
@@ -1,10 +1,15 @@
 package com.example.demo.api.service;
 
+import com.example.demo.api.dto.course.CourseStudentReadAllDto;
 import com.example.demo.api.dto.enrollment.EnrollmentReadAllDto;
+import com.example.demo.api.persistence.entity.Course;
 import com.example.demo.api.persistence.entity.Enrollment;
+import com.example.demo.api.persistence.entity.EnrollmentStatus;
 import com.example.demo.api.persistence.entity.User;
+import com.example.demo.api.persistence.repository.CourseRepository;
 import com.example.demo.api.persistence.repository.EnrollmentRepository;
 import com.example.demo.api.persistence.repository.UserRepository;
+import com.example.demo.error.exception.BadRequestException;
 import com.example.demo.error.exception.NotFoundException;
 import com.example.demo.error.model.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -13,12 +18,15 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class EnrollmentReadService {
     private final EnrollmentRepository enrollmentRepository;
+    private final CourseRepository courseRepository;
     private final UserRepository userRepository;
 
     public EnrollmentReadAllDto readAllByUser(Long userId, Pageable pageable) {
@@ -36,5 +44,32 @@ public class EnrollmentReadService {
                 enrollments.getTotalElements(),
                 enrollments.getTotalPages()
         );
+    }
+
+    public CourseStudentReadAllDto readStudentsByCourse(Long userId, Long courseId) {
+        final User user = userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_NOT_USER));
+        final Course course = courseRepository.findById(courseId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_NOT_COURSE));
+
+        validateCourseOwner(user, course);
+
+        final List<Enrollment> enrollments =
+                enrollmentRepository.findAllByCourseAndEnrollmentStatus(
+                        course,
+                        EnrollmentStatus.CONFIRMED
+                );
+
+        return new CourseStudentReadAllDto(
+                enrollments.stream()
+                        .map(Enrollment::toStudentReadDto)
+                        .toList()
+        );
+    }
+
+    private void validateCourseOwner(User user, Course course) {
+        if (!course.getUser().getId().equals(user.getId())) {
+            throw new BadRequestException(ErrorCode.INVALID_COURSE_OWNER);
+        }
     }
 }

--- a/src/main/java/com/example/demo/error/model/ErrorCode.java
+++ b/src/main/java/com/example/demo/error/model/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
     INVALID_ENROLLMENT_CANCEL_STATUS("결제 완료된 수강 신청만 취소할 수 있습니다.", HttpStatus.BAD_REQUEST),
     INVALID_CANCEL_PERIOD("결제 후 7일 이내에만 취소할 수 있습니다.", HttpStatus.BAD_REQUEST),
     INVALID_ENROLLMENT_CONFIRM_OWNER("본인의 수강 신청만 결제할 수 있습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_SELF_ENROLLMENT("본인이 생성한 강의에는 수강 신청할 수 없습니다.", HttpStatus.BAD_REQUEST),
     INVALID_ENROLLMENT_CONFIRM_STATUS("결제 대기 상태의 수강 신청만 확정할 수 있습니다.", HttpStatus.BAD_REQUEST),
     INVALID_ENROLLMENT_OWNER("본인의 수강 신청만 접근할 수 있습니다.", HttpStatus.BAD_REQUEST),
     INVALID_ROLE("강의 생성은 강사만 가능합니다.", HttpStatus.BAD_REQUEST),


### PR DESCRIPTION
## 📋 CheckList
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. feat: 유저 조회 기능 구현)
- [x] 🏷️ 라벨, 프로젝트는 등록했나요?
- [x] 🧹 코드 스멜은 해결했나요?

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

* close #21 

## 👩‍💻 공유 포인트 및 논의 사항
* 강의 별 수강생 목록 조회 API를 구현했습니다.
* courseId를 기준으로 해당 강의의 수강생 목록을 조회하도록 구현했습니다.
* 해당 강의를 생성한 크리에이터만 조회할 수 있도록 소유자 검증을 추가했습니다.
* 수강 확정 상태(CONFIRMED)인 수강생만 조회 대상으로 제한했습니다.