### PR TITLE
test: 동시성을 위한 통합테스트 구현

### DIFF
--- a/src/main/java/com/example/demo/api/persistence/entity/Course.java
+++ b/src/main/java/com/example/demo/api/persistence/entity/Course.java
@@ -126,8 +126,4 @@ public class Course {
     public void close() {
         this.courseStatus = CourseStatus.CLOSED;
     }
-
-    public void decreaseCapacity() {
-        this.currentCapacity--;
-    }
 }

--- a/src/main/java/com/example/demo/api/persistence/repository/CourseRepository.java
+++ b/src/main/java/com/example/demo/api/persistence/repository/CourseRepository.java
@@ -22,4 +22,13 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
         and c.currentCapacity < c.maxCapacity
         """)
     int increaseCapacityIfAvailable(@Param("courseId") Long courseId);
+
+    @Modifying(flushAutomatically = true)
+    @Query("""
+    update Course c
+    set c.currentCapacity = c.currentCapacity - 1
+    where c.id = :courseId
+    and c.currentCapacity > 0
+    """)
+    int decreaseCapacityIfAvailable(@Param("courseId") Long courseId);
 }

--- a/src/main/java/com/example/demo/api/persistence/repository/EnrollmentRepository.java
+++ b/src/main/java/com/example/demo/api/persistence/repository/EnrollmentRepository.java
@@ -12,6 +12,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -29,6 +30,21 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
             @Param("enrollmentId") Long enrollmentId,
             @Param("confirmedStatus") EnrollmentStatus confirmedStatus,
             @Param("cancelledStatus") EnrollmentStatus cancelledStatus
+    );
+
+    @Modifying(flushAutomatically = true)
+    @Query("""
+        update Enrollment e
+        set e.enrollmentStatus = :confirmedStatus,
+            e.confirmedAt = :confirmedAt
+        where e.id = :enrollmentId
+        and e.enrollmentStatus = :pendingStatus
+        """)
+    int confirmIfPending(
+            @Param("enrollmentId") Long enrollmentId,
+            @Param("pendingStatus") EnrollmentStatus pendingStatus,
+            @Param("confirmedStatus") EnrollmentStatus confirmedStatus,
+            @Param("confirmedAt") LocalDateTime confirmedAt
     );
 
     Page<Enrollment> findAllByUser(User user, Pageable pageable);

--- a/src/main/java/com/example/demo/api/service/EnrollmentCommandService.java
+++ b/src/main/java/com/example/demo/api/service/EnrollmentCommandService.java
@@ -98,8 +98,17 @@ public class EnrollmentCommandService {
 
         final Course course = enrollment.getCourse();
 
-        course.decreaseCapacity();
+        int decreasedCount = courseRepository.decreaseCapacityIfAvailable(course.getId());
+
+        validateDecreaseSuccess(decreasedCount);
+
         waitlistService.promoteNext(course);
+    }
+
+    private static void validateDecreaseSuccess(int decreasedCount) {
+        if (decreasedCount == 0) {
+            throw new BadRequestException(ErrorCode.INVALID_CAPACITY_DECREASE);
+        }
     }
 
     private boolean isFull(Course course) {

--- a/src/main/java/com/example/demo/api/service/EnrollmentCommandService.java
+++ b/src/main/java/com/example/demo/api/service/EnrollmentCommandService.java
@@ -68,7 +68,15 @@ public class EnrollmentCommandService {
             return waitlistService.registerByConfirmFailure(user, course, enrollment);
         }
 
-        enrollment.confirm();
+        final int confirmedCount = enrollmentRepository.confirmIfPending(
+                enrollmentId,
+                EnrollmentStatus.PENDING,
+                EnrollmentStatus.CONFIRMED,
+                LocalDateTime.now()
+        );
+
+        validateConfirmSuccess(confirmedCount);
+
         waitlistService.completeIfPromoted(user, course);
 
         return new EnrollmentResponseDto(
@@ -108,6 +116,12 @@ public class EnrollmentCommandService {
     private static void validateDecreaseSuccess(int decreasedCount) {
         if (decreasedCount == 0) {
             throw new BadRequestException(ErrorCode.INVALID_CAPACITY_DECREASE);
+        }
+    }
+
+    private static void validateConfirmSuccess(int confirmedCount) {
+        if (confirmedCount == 0) {
+            throw new BadRequestException(ErrorCode.ALREADY_CONFIRMED);
         }
     }
 

--- a/src/main/java/com/example/demo/error/model/ErrorCode.java
+++ b/src/main/java/com/example/demo/error/model/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
     INVALID_SELF_ENROLLMENT("본인이 생성한 강의에는 수강 신청할 수 없습니다.", HttpStatus.BAD_REQUEST),
     INVALID_WAITLIST_PRIORITY("대기자가 존재하여 바로 결제할 수 없습니다. 대기열에 등록되었습니다.", HttpStatus.BAD_REQUEST),
     INVALID_ENROLLMENT_CONFIRM_STATUS("결제 대기 상태의 수강 신청만 확정할 수 있습니다.", HttpStatus.BAD_REQUEST),
+    ALREADY_CONFIRMED("이미 확정된 수강 신청입니다.", HttpStatus.BAD_REQUEST),
     INVALID_ENROLLMENT_OWNER("본인의 수강 신청만 접근할 수 있습니다.", HttpStatus.BAD_REQUEST),
     ALREADY_WAITING("이미 해당 강의의 대기열에 등록되어 있습니다.", HttpStatus.BAD_REQUEST),
     INVALID_ROLE("강의 생성은 강사만 가능합니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/example/demo/error/model/ErrorCode.java
+++ b/src/main/java/com/example/demo/error/model/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
 
     // BadRequest 400
     ALREADY_ENROLLED("이미 수강 신청한 강의입니다.", HttpStatus.BAD_REQUEST),
+    INVALID_CAPACITY_DECREASE("현재 수강 인원은 0 미만으로 감소할 수 없습니다.", HttpStatus.BAD_REQUEST),
     INVALID_COURSE_CLOSE_STATUS("모집 중인 강의만 마감할 수 있습니다.", HttpStatus.BAD_REQUEST),
     INVALID_ENROLLMENT_CANCEL_STATUS("결제 완료된 수강 신청만 취소할 수 있습니다.", HttpStatus.BAD_REQUEST),
     INVALID_CANCEL_PERIOD("결제 후 7일 이내에만 취소할 수 있습니다.", HttpStatus.BAD_REQUEST),

--- a/src/test/java/com/example/demo/api/integration/enrollment/EnrollmentConcurrencyTest.java
+++ b/src/test/java/com/example/demo/api/integration/enrollment/EnrollmentConcurrencyTest.java
@@ -133,6 +133,75 @@ public class EnrollmentConcurrencyTest {
     }
 
     @Test
+    @DisplayName("수강 확정 동시성 테스트 - 같은 사용자가 동일 수강 신청을 동시에 확정해도 한 번만 확정된다")
+    void confirm_concurrency_same_user_same_enrollment_only_once_success() throws Exception {
+        // Given
+        int threadCount = 100;
+
+        User creator = userRepository.save(User.create("강사", Role.CREATOR));
+        User student = userRepository.save(User.create("학생", Role.STUDENT));
+
+        Course course = createOpenCourse(creator, 10, 0);
+        Course savedCourse = courseRepository.save(course);
+
+        Enrollment enrollment = enrollmentRepository.save(
+                Enrollment.create(student, savedCourse)
+        );
+
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch readyLatch = new CountDownLatch(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+
+        List<Future<Boolean>> futures = new ArrayList<>();
+
+        for (int i = 0; i < threadCount; i++) {
+            futures.add(executorService.submit(() -> {
+                readyLatch.countDown();
+                startLatch.await();
+
+                try {
+                    enrollmentCommandService.confirm(
+                            student.getId(),
+                            enrollment.getId()
+                    );
+                    return true;
+                } catch (Exception e) {
+                    return false;
+                }
+            }));
+        }
+
+        readyLatch.await();
+        startLatch.countDown();
+
+        int successCount = 0;
+        int failCount = 0;
+
+        for (Future<Boolean> future : futures) {
+            if (future.get()) {
+                successCount++;
+            } else {
+                failCount++;
+            }
+        }
+
+        executorService.shutdown();
+
+        entityManager.clear();
+
+        // Then
+        Course resultCourse = courseRepository.findById(savedCourse.getId()).orElseThrow();
+        Enrollment resultEnrollment = enrollmentRepository.findById(enrollment.getId()).orElseThrow();
+
+        assertThat(successCount).isEqualTo(1);
+        assertThat(failCount).isEqualTo(threadCount - 1);
+
+        assertThat(resultCourse.getCurrentCapacity()).isEqualTo(1);
+        assertThat(resultEnrollment.getEnrollmentStatus()).isEqualTo(EnrollmentStatus.CONFIRMED);
+        assertThat(resultEnrollment.getConfirmedAt()).isNotNull();
+    }
+
+    @Test
     @DisplayName("수강 취소 동시성 테스트 - 같은 수강 신청을 동시에 취소해도 정원은 한 번만 감소한다")
     void cancel_concurrency_decrease_capacity_only_once_when_same_enrollment_cancelled() throws Exception {
         // Given
@@ -198,6 +267,91 @@ public class EnrollmentConcurrencyTest {
 
         assertThat(resultCourse.getCurrentCapacity()).isEqualTo(0);
         assertThat(resultEnrollment.getEnrollmentStatus()).isEqualTo(EnrollmentStatus.CANCELLED);
+    }
+
+    @Test
+    @DisplayName("수강 취소 동시성 테스트 - 서로 다른 두 사용자가 동시에 취소하면 둘 다 취소되고 정원은 두 번 감소한다")
+    void cancel_concurrency_two_different_users_both_success() throws Exception {
+        // Given
+        int threadCount = 2;
+
+        User creator = userRepository.save(User.create("강사", Role.CREATOR));
+        User studentA = userRepository.save(User.create("학생A", Role.STUDENT));
+        User studentB = userRepository.save(User.create("학생B", Role.STUDENT));
+
+        Course course = createOpenCourse(creator, 10, 2);
+        Course savedCourse = courseRepository.save(course);
+
+        Enrollment enrollmentA = Enrollment.create(studentA, savedCourse);
+        enrollmentA.confirm();
+        Enrollment savedEnrollmentA = enrollmentRepository.save(enrollmentA);
+
+        Enrollment enrollmentB = Enrollment.create(studentB, savedCourse);
+        enrollmentB.confirm();
+        Enrollment savedEnrollmentB = enrollmentRepository.save(enrollmentB);
+
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch readyLatch = new CountDownLatch(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+
+        List<Future<Boolean>> futures = new ArrayList<>();
+
+        futures.add(executorService.submit(() -> {
+            readyLatch.countDown();
+            startLatch.await();
+
+            try {
+                enrollmentCommandService.cancel(
+                        studentA.getId(),
+                        savedEnrollmentA.getId()
+                );
+                return true;
+            } catch (Exception e) {
+                return false;
+            }
+        }));
+
+        futures.add(executorService.submit(() -> {
+            readyLatch.countDown();
+            startLatch.await();
+
+            try {
+                enrollmentCommandService.cancel(
+                        studentB.getId(),
+                        savedEnrollmentB.getId()
+                );
+                return true;
+            } catch (Exception e) {
+                return false;
+            }
+        }));
+
+        readyLatch.await();
+        startLatch.countDown();
+
+        int successCount = 0;
+
+        for (Future<Boolean> future : futures) {
+            if (future.get()) {
+                successCount++;
+            }
+        }
+
+        executorService.shutdown();
+
+        entityManager.clear();
+
+        // Then
+        Course resultCourse = courseRepository.findById(savedCourse.getId()).orElseThrow();
+        Enrollment resultEnrollmentA = enrollmentRepository.findById(savedEnrollmentA.getId()).orElseThrow();
+        Enrollment resultEnrollmentB = enrollmentRepository.findById(savedEnrollmentB.getId()).orElseThrow();
+
+        assertThat(successCount).isEqualTo(2);
+
+        assertThat(resultCourse.getCurrentCapacity()).isEqualTo(0);
+
+        assertThat(resultEnrollmentA.getEnrollmentStatus()).isEqualTo(EnrollmentStatus.CANCELLED);
+        assertThat(resultEnrollmentB.getEnrollmentStatus()).isEqualTo(EnrollmentStatus.CANCELLED);
     }
 
     private Course createOpenCourse(User creator, int maxCapacity, int currentCapacity) {

--- a/src/test/java/com/example/demo/api/integration/enrollment/EnrollmentConcurrencyTest.java
+++ b/src/test/java/com/example/demo/api/integration/enrollment/EnrollmentConcurrencyTest.java
@@ -1,0 +1,219 @@
+package com.example.demo.api.integration.enrollment;
+
+import com.example.demo.api.dto.enrollment.EnrollmentResponseDto;
+import com.example.demo.api.dto.enrollment.EnrollmentResult;
+import com.example.demo.api.persistence.entity.*;
+import com.example.demo.api.persistence.repository.CourseRepository;
+import com.example.demo.api.persistence.repository.EnrollmentRepository;
+import com.example.demo.api.persistence.repository.UserRepository;
+import com.example.demo.api.persistence.repository.WaitlistRepository;
+import com.example.demo.api.service.EnrollmentCommandService;;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+public class EnrollmentConcurrencyTest {
+    @Autowired
+    private EnrollmentCommandService enrollmentCommandService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private CourseRepository courseRepository;
+
+    @Autowired
+    private EnrollmentRepository enrollmentRepository;
+
+    @Autowired
+    private WaitlistRepository waitlistRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @AfterEach
+    void tearDown() {
+        waitlistRepository.deleteAllInBatch();
+        enrollmentRepository.deleteAllInBatch();
+        courseRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @DisplayName("수강 확정 동시성 테스트 - 정원이 1개 남았을 때 동시에 요청해도 1명만 확정된다")
+    void confirm_concurrency_only_one_success_when_one_capacity_left() throws Exception {
+        // Given
+        int threadCount = 100;
+
+        User creator = userRepository.save(User.create("강사", Role.CREATOR));
+
+        Course course = createOpenCourse(creator, 10, 9);
+        Course savedCourse = courseRepository.save(course);
+
+        List<Enrollment> enrollments = new ArrayList<>();
+
+        for (int i = 0; i < threadCount; i++) {
+            User student = userRepository.save(User.create("학생" + i, Role.STUDENT));
+            Enrollment enrollment = enrollmentRepository.save(
+                    Enrollment.create(student, savedCourse)
+            );
+            enrollments.add(enrollment);
+        }
+
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch readyLatch = new CountDownLatch(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+
+        List<Future<EnrollmentResponseDto>> futures = new ArrayList<>();
+
+        for (Enrollment enrollment : enrollments) {
+            futures.add(executorService.submit(() -> {
+                readyLatch.countDown();
+                startLatch.await();
+
+                return enrollmentCommandService.confirm(
+                        enrollment.getUser().getId(),
+                        enrollment.getId()
+                );
+            }));
+        }
+
+        readyLatch.await();
+        startLatch.countDown();
+
+        List<EnrollmentResponseDto> responses = new ArrayList<>();
+
+        for (Future<EnrollmentResponseDto> future : futures) {
+            responses.add(future.get());
+        }
+
+        executorService.shutdown();
+
+        entityManager.clear();
+
+        // Then
+        Course resultCourse = courseRepository.findById(savedCourse.getId()).orElseThrow();
+
+        List<Enrollment> confirmedEnrollments =
+                enrollmentRepository.findAllByCourseAndEnrollmentStatus(
+                        resultCourse,
+                        EnrollmentStatus.CONFIRMED
+                );
+
+        List<Enrollment> cancelledEnrollments =
+                enrollmentRepository.findAllByCourseAndEnrollmentStatus(
+                        resultCourse,
+                        EnrollmentStatus.CANCELLED
+                );
+
+        long confirmedResponseCount = responses.stream()
+                .filter(response -> response.type() == EnrollmentResult.CONFIRMED)
+                .count();
+
+        long waitlistResponseCount = responses.stream()
+                .filter(response -> response.type() == EnrollmentResult.WAITLIST)
+                .count();
+
+        assertThat(resultCourse.getCurrentCapacity()).isEqualTo(10);
+        assertThat(confirmedEnrollments).hasSize(1);
+        assertThat(cancelledEnrollments).hasSize(threadCount - 1);
+
+        assertThat(confirmedResponseCount).isEqualTo(1);
+        assertThat(waitlistResponseCount).isEqualTo(threadCount - 1);
+    }
+
+    @Test
+    @DisplayName("수강 취소 동시성 테스트 - 같은 수강 신청을 동시에 취소해도 정원은 한 번만 감소한다")
+    void cancel_concurrency_decrease_capacity_only_once_when_same_enrollment_cancelled() throws Exception {
+        // Given
+        int threadCount = 100;
+
+        User creator = userRepository.save(User.create("강사", Role.CREATOR));
+        User student = userRepository.save(User.create("학생", Role.STUDENT));
+
+        Course course = createOpenCourse(creator, 10, 1);
+        Course savedCourse = courseRepository.save(course);
+
+        Enrollment enrollment = Enrollment.create(student, savedCourse);
+        enrollment.confirm();
+        Enrollment savedEnrollment = enrollmentRepository.save(enrollment);
+
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch readyLatch = new CountDownLatch(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+
+        List<Future<Boolean>> futures = new ArrayList<>();
+
+        for (int i = 0; i < threadCount; i++) {
+            futures.add(executorService.submit(() -> {
+                readyLatch.countDown();
+                startLatch.await();
+
+                try {
+                    enrollmentCommandService.cancel(
+                            student.getId(),
+                            savedEnrollment.getId()
+                    );
+                    return true;
+                } catch (Exception e) {
+                    return false;
+                }
+            }));
+        }
+
+        readyLatch.await();
+        startLatch.countDown();
+
+        int successCount = 0;
+        int failCount = 0;
+
+        for (Future<Boolean> future : futures) {
+            if (future.get()) {
+                successCount++;
+            } else {
+                failCount++;
+            }
+        }
+
+        executorService.shutdown();
+
+        entityManager.clear();
+
+        // Then
+        Course resultCourse = courseRepository.findById(savedCourse.getId()).orElseThrow();
+        Enrollment resultEnrollment = enrollmentRepository.findById(savedEnrollment.getId()).orElseThrow();
+
+        assertThat(successCount).isEqualTo(1);
+        assertThat(failCount).isEqualTo(threadCount - 1);
+
+        assertThat(resultCourse.getCurrentCapacity()).isEqualTo(0);
+        assertThat(resultEnrollment.getEnrollmentStatus()).isEqualTo(EnrollmentStatus.CANCELLED);
+    }
+
+    private Course createOpenCourse(User creator, int maxCapacity, int currentCapacity) {
+        Course course = Course.create(
+                "테스트 강의",
+                "테스트 설명",
+                10000,
+                maxCapacity,
+                LocalDate.now(),
+                LocalDate.now().plusDays(30),
+                creator
+        );
+
+        ReflectionTestUtils.setField(course, "currentCapacity", currentCapacity);
+        course.open();
+
+        return course;
+    }
+}

--- a/src/test/java/com/example/demo/api/service/EnrollmentCommandServiceTest.java
+++ b/src/test/java/com/example/demo/api/service/EnrollmentCommandServiceTest.java
@@ -433,6 +433,7 @@ public class EnrollmentCommandServiceTest {
     @DisplayName("수강 취소 성공 - 확정된 수강 신청이면 취소하고 정원을 감소시킨 뒤 다음 대기자를 승격한다")
     void cancel_success() {
         // Given
+        Course course = createOpenCourse(10L, creator, 10, 1);
         Enrollment enrollment = createConfirmedEnrollment(100L, student, course);
 
         when(userRepository.findById(student.getId()))
@@ -444,18 +445,19 @@ public class EnrollmentCommandServiceTest {
                 EnrollmentStatus.CONFIRMED,
                 EnrollmentStatus.CANCELLED
         )).thenReturn(1);
+        when(courseRepository.decreaseCapacityIfAvailable(course.getId()))
+                .thenReturn(1);
 
         // When
         enrollmentCommandService.cancel(student.getId(), enrollment.getId());
 
         // Then
-        assertThat(course.getCurrentCapacity()).isEqualTo(-1);
-
         verify(enrollmentRepository).cancelIfConfirmed(
                 enrollment.getId(),
                 EnrollmentStatus.CONFIRMED,
                 EnrollmentStatus.CANCELLED
         );
+        verify(courseRepository).decreaseCapacityIfAvailable(course.getId());
         verify(waitlistService).promoteNext(course);
     }
 

--- a/src/test/java/com/example/demo/api/service/EnrollmentCommandServiceTest.java
+++ b/src/test/java/com/example/demo/api/service/EnrollmentCommandServiceTest.java
@@ -19,8 +19,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Optional;
 
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.any;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -252,6 +255,12 @@ public class EnrollmentCommandServiceTest {
                 .thenReturn(false);
         when(courseRepository.increaseCapacityIfAvailable(course.getId()))
                 .thenReturn(1);
+        when(enrollmentRepository.confirmIfPending(
+                eq(enrollment.getId()),
+                eq(EnrollmentStatus.PENDING),
+                eq(EnrollmentStatus.CONFIRMED),
+                any(LocalDateTime.class)
+        )).thenReturn(1);
 
         // When
         EnrollmentResponseDto response =
@@ -260,9 +269,14 @@ public class EnrollmentCommandServiceTest {
         // Then
         assertThat(response.type()).isEqualTo(EnrollmentResult.CONFIRMED);
         assertThat(response.message()).isEqualTo(EnrollmentResult.CONFIRMED.getMessage());
-        assertThat(enrollment.getEnrollmentStatus()).isEqualTo(EnrollmentStatus.CONFIRMED);
-        assertThat(enrollment.getConfirmedAt()).isNotNull();
 
+        verify(courseRepository).increaseCapacityIfAvailable(course.getId());
+        verify(enrollmentRepository).confirmIfPending(
+                eq(enrollment.getId()),
+                eq(EnrollmentStatus.PENDING),
+                eq(EnrollmentStatus.CONFIRMED),
+                any(LocalDateTime.class)
+        );
         verify(waitlistService).completeIfPromoted(student, course);
         verify(waitlistService, never())
                 .registerByConfirmFailure(any(User.class), any(Course.class), any(Enrollment.class));
@@ -417,6 +431,12 @@ public class EnrollmentCommandServiceTest {
                 .thenReturn(true);
         when(courseRepository.increaseCapacityIfAvailable(course.getId()))
                 .thenReturn(1);
+        when(enrollmentRepository.confirmIfPending(
+                eq(enrollment.getId()),
+                eq(EnrollmentStatus.PENDING),
+                eq(EnrollmentStatus.CONFIRMED),
+                any(LocalDateTime.class)
+        )).thenReturn(1);
 
         // When
         EnrollmentResponseDto response =
@@ -424,8 +444,14 @@ public class EnrollmentCommandServiceTest {
 
         // Then
         assertThat(response.type()).isEqualTo(EnrollmentResult.CONFIRMED);
-        assertThat(enrollment.getEnrollmentStatus()).isEqualTo(EnrollmentStatus.CONFIRMED);
 
+        verify(courseRepository).increaseCapacityIfAvailable(course.getId());
+        verify(enrollmentRepository).confirmIfPending(
+                eq(enrollment.getId()),
+                eq(EnrollmentStatus.PENDING),
+                eq(EnrollmentStatus.CONFIRMED),
+                any(LocalDateTime.class)
+        );
         verify(waitlistService).completeIfPromoted(student, course);
     }
 


### PR DESCRIPTION
## 📋 CheckList
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. feat: 유저 조회 기능 구현)
- [ ] 🏷️ 라벨, 프로젝트는 등록했나요?
- [ ] 🧹 코드 스멜은 해결했나요?

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

* close #27 

## 👩‍💻 공유 포인트 및 논의 사항
## 공유 포인트
* 수강 확정(confirm)과 수강 취소(cancel) 로직에 대해 동시성 통합 테스트를 추가했습니다.
* Mockito 기반 단위 테스트가 아닌 실제 Spring Context와 Repository를 사용하는 통합 테스트로 작성했습니다.
* ExecutorService와 CountDownLatch를 사용해 여러 요청이 최대한 동시에 실행되도록 구성했습니다.

---

## Confirm 동시성 테스트

### 1. 한 사용자의 동시 요청 (더블클릭)
* 한 사용자가 동일한 수강 신청(Enrollment)에 대해 수강 확정 요청을 동시에 여러 번 보내는 상황을 검증했습니다.
* `Enrollment` 상태를 `PENDING → CONFIRMED`로 변경하는 로직을 DB 원자적 업데이트(`confirmIfPending`)로 처리하여 중복 확정을 방지했습니다.

#### 결과:
- 수강 확정 성공: 1번
- 나머지 요청: 실패
- currentCapacity는 1번만 증가
- 동일한 수강 신청이 중복으로 확정되지 않음

---

### 2. 여러 사용자의 동시 요청
* 정원이 1개만 남은 강의에 여러 사용자가 동시에 수강 확정 요청을 보내는 상황을 검증했습니다.
* `currentCapacity < maxCapacity` 조건을 포함한 DB 원자적 업데이트를 통해 정원 초과를 방지했습니다.

#### 결과:
- 수강 확정 성공: 1명
- 나머지 요청: 대기열 등록
- currentCapacity는 maxCapacity를 초과하지 않음

---

## Cancel 동시성 테스트

### 1. 한 사용자의 동시 요청 (더블클릭)
* 한 사용자가 동일한 수강 신청 건에 대해 취소 요청을 동시에 여러 번 보내는 상황을 검증했습니다.
* `CONFIRMED → CANCELLED` 상태 변경을 DB 원자적 업데이트(`cancelIfConfirmed`)로 처리하여 중복 취소를 방지했습니다.

#### 결과:
- 취소 성공: 1번
- 나머지 요청: 실패
- currentCapacity는 한 번만 감소
- currentCapacity가 음수로 내려가지 않음

---

### 2. 여러 사용자의 동시 요청
* 서로 다른 사용자가 각각 본인의 수강 신청 건을 동시에 취소하는 상황을 검증했습니다.
* `currentCapacity` 감소를 DB 원자적 업데이트로 처리하여 Lost Update 문제를 방지했습니다.

#### 결과:
- 모든 취소 요청 성공
- currentCapacity는 취소된 인원 수만큼 정확히 감소
- 동시성 상황에서도 정합성이 유지됨